### PR TITLE
Изменения javascript

### DIFF
--- a/assets/components/dadata/js/web/default.js
+++ b/assets/components/dadata/js/web/default.js
@@ -87,14 +87,18 @@ modxDaData = {
 			/** subject **/
 			var subject = config.subject;
 			if (!!subject) {
+				var i = 0;
 				$.each(subject, function (name, key) {
 					var $input = parent.find('[name="' + name + '"]');
 					if (!!!$input) {
 						return true;
 					}
+					i++;
 					var ovalue = $input.val();
 					var nvalue = data[key.toLowerCase()];
-					modxDaData.suggestions.setvalue($input, nvalue);
+					setTimeout(function(){
+						modxDaData.suggestions.setvalue($input, nvalue);
+					},i*100);
 				});
 			}
 


### PR DESCRIPTION
Корректировка задержек для установки значений полей заказа (индекс, город, улица, дом, комната) для оформления заказа в minishop2 - последняя версия минишопа не успевает корректно сохранять значения в $_SESSION PHP ( https://github.com/bezumkin/miniShop2/blob/53f541cb4fabe3ad32f9e0608a5abf5d25cd9a4d/core/components/minishop2/model/minishop2/msorderhandler.class.php#L143 ) . Возможно это из-за настроек связки nginx+php-fpm. С задержками работает хорошо, на работу не влияет.
